### PR TITLE
add gpu support to worker container

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@
 
 Its recommended to use [docker](https://docs.docker.com/get-docker/) and [docker-compose](https://docs.docker.com/compose/install/)
 
-
 ### Docker
 
 To setup all services just run following command in the root directory.
 
 **Before running the following command, please update the environment variable `MINIO_ENDPOINT` inside the `docker-compose.yml` to an external reachable hostname! This container is called directly from the frontend.**
+
+**If you want the worker to support your gpu you have to install the [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on the host**
 
 ```sh
 docker compose up -d
@@ -42,7 +43,6 @@ npm i
 
 npm run dev
 ```
-
 
 #### Database
 
@@ -76,40 +76,40 @@ python3 main.py
 
 ### Dashboard
 
-| NAME | DEFAULT VALUE | DESCRIPTION |
-| ----------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `DATABASE_URL` | `postgresql://admin:admin@localhost:5433/postgres?schema=public` | It is required for prisma to connect with the postgres database. |
-| `RABBITMQ_URL` | `amqp://rabbit:rabbit@localhost` | URL of the rabbitmq |
-| `QUEUE_NAME` | `jobs` | The name of the job-queue | 
-| `MINIO_ENDPOINT` | `localhost` | This is the endpoint of minio server. It will be the IP address of the server. |
-| `MINIO_PORT` | `9000` | Minio port for communication from dashboard. |
-| `MINIO_ACCESS_KEY` | `shoutoutdevuser` | Access key for minio dev user. |
-| `MINIO_SECRET_KEY` | `shoutoutdevuser` | Secret key for minio dev user. |
-| `MINIO_JOB_BUCKET` | `shoutout-job-bucket` | Bucket name to store all audio files. |
-| `DOWNLOAD_FILE_TARGET_DIR` | `finished-files/` | Folder on S3-Bucket containing transcribed files | 
-| `FINISHED_FILE_FORMAT` | `.txt` | The download format of the finished file |
-| `UPLOAD_FILE_TARGET_DIR` | `to-transcribe/` | Folder on S3-Bucket to upload mp3 files to |
-| `MINIO_SSL_ENABLED` | `false` | SSL setting for S3 Bucket |
+| NAME                       | DEFAULT VALUE                                                    | DESCRIPTION                                                                    |
+| -------------------------- | ---------------------------------------------------------------- | ------------------------------------------------------------------------------ |
+| `DATABASE_URL`             | `postgresql://admin:admin@localhost:5433/postgres?schema=public` | It is required for prisma to connect with the postgres database.               |
+| `RABBITMQ_URL`             | `amqp://rabbit:rabbit@localhost`                                 | URL of the rabbitmq                                                            |
+| `QUEUE_NAME`               | `jobs`                                                           | The name of the job-queue                                                      |
+| `MINIO_ENDPOINT`           | `localhost`                                                      | This is the endpoint of minio server. It will be the IP address of the server. |
+| `MINIO_PORT`               | `9000`                                                           | Minio port for communication from dashboard.                                   |
+| `MINIO_ACCESS_KEY`         | `shoutoutdevuser`                                                | Access key for minio dev user.                                                 |
+| `MINIO_SECRET_KEY`         | `shoutoutdevuser`                                                | Secret key for minio dev user.                                                 |
+| `MINIO_JOB_BUCKET`         | `shoutout-job-bucket`                                            | Bucket name to store all audio files.                                          |
+| `DOWNLOAD_FILE_TARGET_DIR` | `finished-files/`                                                | Folder on S3-Bucket containing transcribed files                               |
+| `FINISHED_FILE_FORMAT`     | `.txt`                                                           | The download format of the finished file                                       |
+| `UPLOAD_FILE_TARGET_DIR`   | `to-transcribe/`                                                 | Folder on S3-Bucket to upload mp3 files to                                     |
+| `MINIO_SSL_ENABLED`        | `false`                                                          | SSL setting for S3 Bucket                                                      |
 
 ### Worker
 
-| NAME | DEFAULT VALUE | DESCRIPTION |
-| ----------------------------- | ---------------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| `DATABASE_HOST` | `localhost` | PostgresDB host |
-| `DATABASE_NAME` | `postgres` | Database name |
-| `DATABASE_USER` | `admin` | PostgresDB username |
-| `DATABASE_PASSWORD` | `admin` | PostgresDB password |
-| `DATABASE_PORT` | `5433` | PostgresDB port|
-| `RABBITMQ_HOST` | `localhost` | Rabbitmq host |
-| `RABBITMQ_USER` | `rabbit` | Username for rabbitmq |
-| `RABBITMQ_PASSWORD` | `rabbit` | Password for rabbitmq |
-| `RABBITMQ_QUEUE` | `jobs` | The name of the job queue |
-| `MINIO_JOB_BUCKET` | `shoutout-job-bucket` | Bucket name to store all audio files. |
-| `MINIO_SECRET_KEY` | `shoutoutdevuser` | Secret key for minio dev user. |
-| `MINIO_ACCESS_KEY` | `shoutoutdevuser` | Access key for minio dev user. |
-| `MINIO_URL` | `http://localhost:9000` | URL of S3 Bucket |
-| `TMP_FILE_DIR` | `tmp_downloads` | Local directory where all temporary files which are needed for transcription are stored |
-| `UPLOAD_FILE_TARGET_DIR` | `finished-files/` | Folder on S3-Bucket to upload finished transcription to |
-| `DOWNLOAD_FILE_DIR` | `to-transcribe/` | Folder on S3-Bucket containing mp3 files to transcribe |
-| `WHISPER_MODEL` | `large-v3` | openai whisper [model size](https://github.com/openai/whisper#available-models-and-languages) |
-| `FINISHED_FILE_FORMAT` | `.txt` | File format of the transcribed file |
+| NAME                     | DEFAULT VALUE           | DESCRIPTION                                                                                   |
+| ------------------------ | ----------------------- | --------------------------------------------------------------------------------------------- |
+| `DATABASE_HOST`          | `localhost`             | PostgresDB host                                                                               |
+| `DATABASE_NAME`          | `postgres`              | Database name                                                                                 |
+| `DATABASE_USER`          | `admin`                 | PostgresDB username                                                                           |
+| `DATABASE_PASSWORD`      | `admin`                 | PostgresDB password                                                                           |
+| `DATABASE_PORT`          | `5433`                  | PostgresDB port                                                                               |
+| `RABBITMQ_HOST`          | `localhost`             | Rabbitmq host                                                                                 |
+| `RABBITMQ_USER`          | `rabbit`                | Username for rabbitmq                                                                         |
+| `RABBITMQ_PASSWORD`      | `rabbit`                | Password for rabbitmq                                                                         |
+| `RABBITMQ_QUEUE`         | `jobs`                  | The name of the job queue                                                                     |
+| `MINIO_JOB_BUCKET`       | `shoutout-job-bucket`   | Bucket name to store all audio files.                                                         |
+| `MINIO_SECRET_KEY`       | `shoutoutdevuser`       | Secret key for minio dev user.                                                                |
+| `MINIO_ACCESS_KEY`       | `shoutoutdevuser`       | Access key for minio dev user.                                                                |
+| `MINIO_URL`              | `http://localhost:9000` | URL of S3 Bucket                                                                              |
+| `TMP_FILE_DIR`           | `tmp_downloads`         | Local directory where all temporary files which are needed for transcription are stored       |
+| `UPLOAD_FILE_TARGET_DIR` | `finished-files/`       | Folder on S3-Bucket to upload finished transcription to                                       |
+| `DOWNLOAD_FILE_DIR`      | `to-transcribe/`        | Folder on S3-Bucket containing mp3 files to transcribe                                        |
+| `WHISPER_MODEL`          | `large-v3`              | openai whisper [model size](https://github.com/openai/whisper#available-models-and-languages) |
+| `FINISHED_FILE_FORMAT`   | `.txt`                  | File format of the transcribed file                                                           |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -99,6 +99,9 @@ services:
       - minio
       - rabbitmq
     deploy:
+      mode: replicated
+      replicas: 2
+      # If you haven't installed the nividia-container-toolkit delete the following part:
       resources:
         reservations:
           devices:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       - MINIO_ACCESS_KEY=shoutoutdevuser
       - MINIO_SECRET_KEY=shoutoutdevuser
       - MINIO_JOB_BUCKET=shoutout-job-bucket
-      - MINIO_SSL_ENABLED=false # TODO toggle if your endpoint is supporting valid https 
+      - MINIO_SSL_ENABLED=false # TODO toggle if your endpoint is supporting valid https
       - RABBITMQ_URL=amqp://rabbit:rabbit@rabbitmq
       - QUEUE_NAME=jobs
       - DATABASE_URL=postgresql://admin:admin@postgres:5432/postgres?schema=public
@@ -98,6 +98,13 @@ services:
       - postgres
       - minio
       - rabbitmq
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: 1
+              capabilities: [gpu]
 
 volumes:
   shoutout-db-data:


### PR DESCRIPTION
1. I had to intstall the [nvidia-container-toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html) on the host
2. I had to expand the `docker-compose.yml` as you can see in the changes. [Documentation](https://docs.docker.com/compose/gpu-support/)

After that the worker container had access to my graphics card and used it for transcribing/diarization

TODO:
- Can we make the deploy things optional inside the `docker-compose.yml`? If the host has not installed nvidia-container-toolkit, The worker-container wont start
- We have to update the docs

Closes #10 
