### PR TITLE
fix: revert dependency update and pin version manually

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -44,7 +44,6 @@ jobs:
   
   build:
     name: Build docker image
-    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -52,15 +51,23 @@ jobs:
         include:
           - context: dashboard
             image: dashboard
+            build_always: true
           - context: worker
             model: large-v3
             image:  worker-large
+            build_always: false
           - context: worker
             model: medium
             image: worker-medium
+            build_always: false 
           - context: worker
             model: small
             image: worker-small
+            build_always: false
+          - context: worker
+            model: tiny
+            image: worker-tiny
+            build_always: true
     permissions:
       contents: read
       packages: write
@@ -68,13 +75,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-      
+        if: ${{ matrix.build_always || github.ref == 'refs/heads/main' }} 
+
       - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ github.token }}
+        if: ${{ matrix.build_always || github.ref == 'refs/heads/main' }} 
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -85,6 +94,7 @@ jobs:
             type=ref, event=pr
             type=raw, value=${{ matrix.model }}, enable=${{ matrix.image != 'dashboard' }} # tags for model-sizes
             type=raw, value=latest , enable=${{ (github.ref == format('refs/heads/{0}', 'main')) && (matrix.image == 'worker-large' || matrix.image == 'dashboard')}} # tag worker large and dashboard branch as latest
+        if: ${{ matrix.build_always || github.ref == 'refs/heads/main' }} 
 
       - name: Build and push Docker images
         uses: docker/build-push-action@v5
@@ -96,3 +106,5 @@ jobs:
             HUGGINGFACE_APIKEY=${{ secrets.HUGGINGFACE_APIKEY }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+        if: ${{ matrix.build_always || github.ref == 'refs/heads/main' }} 
+

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -12,7 +12,7 @@ s3transfer==0.7.0
 six==1.16.0
 types-pika==1.2.0b1
 typing_extensions==4.8.0
-urllib3==2.2.0
+urllib3==1.26.17
 torch==2.0.0
 torchaudio==2.0.0
 pydub==0.25.1

--- a/worker/requirements.txt
+++ b/worker/requirements.txt
@@ -1,5 +1,5 @@
-boto3==1.28.60
-botocore==1.31.60
+boto3==1.34.40
+botocore==1.34.40
 jmespath==1.0.1
 pika==1.3.2
 psycopg2-binary==2.9.8
@@ -8,11 +8,11 @@ pydantic-settings==2.0.3
 pydantic_core==2.10.1
 python-dateutil==2.8.2
 python-dotenv==1.0.0
-s3transfer==0.7.0
+s3transfer==0.10.0
 six==1.16.0
 types-pika==1.2.0b1
 typing_extensions==4.8.0
-urllib3==1.26.17
+urllib3==2.0.7
 torch==2.0.0
 torchaudio==2.0.0
 pydub==0.25.1


### PR DESCRIPTION
This reverts commit 60be574c562a363b4a09eb9c9274c67bed844481 and manually pins the coherent dependencies. (due to failing pipeline on main)

This has to be done because the package `botocore` is not compatible with v2.2.0 of `urllib3`. [see here](https://github.com/boto/botocore/issues/2926)
The maximum we can go to is v2.0.7 [see here](https://github.com/boto/botocore/pull/3034)

