### PR TITLE
ignore urllib

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,6 +20,15 @@
     "rangeStrategy": "pin",
     "packageRules": [
         {
+            "matchPackagePatterns": [
+                "urllib3"
+            ],
+            "matchManagers": [
+                "pip_requirements"
+            ],
+            "enabled": false
+        },
+        {
             "groupName": "all non-major {{manager}} dependencies",
             "matchUpdateTypes": [
                 "minor",


### PR DESCRIPTION
 `botocore` is not compatible with v2.2.0 of `urllib3`. [see here](https://github.com/boto/botocore/issues/2926)