### PR TITLE
feat: introduce turbo model

### DIFF
--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -97,7 +97,7 @@ jobs:
           tags: |
             type=ref, event=pr
             type=raw, value=${{ matrix.model }}, enable=${{ matrix.image != 'dashboard' }} # tags for model-sizes
-            type=raw, value=latest , enable=${{ (github.ref == format('refs/heads/{0}', 'main')) && (matrix.image == 'worker-large' || matrix.image == 'dashboard')}} # tag worker large and dashboard branch as latest
+            type=raw, value=latest , enable=${{ (github.ref == format('refs/heads/{0}', 'main')) && (matrix.image == 'worker-turbo' || matrix.image == 'dashboard')}} # tag worker turbo and dashboard branch as latest
         if: ${{ matrix.build_always || github.ref == 'refs/heads/main' }} 
 
       - name: Build and push Docker images

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -53,6 +53,10 @@ jobs:
             image: dashboard
             build_always: true
           - context: worker
+            model: turbo
+            image:  worker-turbo
+            build_always: false
+          - context: worker
             model: large-v3
             image:  worker-large
             build_always: false


### PR DESCRIPTION
Since September 2024 large-v3-turbo is available.

As `large-v3-turbo` actually offers way better specs, we tag it with `latest`.

> Additionally, the turbo model is an optimized version of large-v3 that offers faster transcription speed with a minimal degradation in accuracy. [[1]](https://github.com/openai/whisper?tab=readme-ov-file#available-models-and-languages) 